### PR TITLE
Routes redirect core issue

### DIFF
--- a/projects/app1/src/app/app-routing.module.ts
+++ b/projects/app1/src/app/app-routing.module.ts
@@ -5,15 +5,13 @@ import { View2Component } from './pages/view2.component';
 
 
 const routes: Routes = [
-  { path: '', redirectTo: 'app1', pathMatch: 'full' },
   {
     path: 'app1', children: [
       { path: '', redirectTo: 'view1', pathMatch: 'full' },
       { path: 'view1', component: View1Component },
       { path: 'view2', component: View2Component },
     ]
-  },
-  { path: '*', redirectTo: 'app1', pathMatch: 'full' } // FIXME: Esta parte aún no funciona!
+  }
 ];
 
 @NgModule({

--- a/projects/app1/src/app/app-routing.module.ts
+++ b/projects/app1/src/app/app-routing.module.ts
@@ -2,20 +2,23 @@ import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 import { View1Component } from './pages/view1.component';
 import { View2Component } from './pages/view2.component';
+import { AppComponent } from './app.component';
 
 
 const routes: Routes = [
   {
-    path: 'app1', children: [
-      { path: '', redirectTo: 'view1', pathMatch: 'full' },
+    path: 'app1',
+    component: AppComponent,
+    children: [
       { path: 'view1', component: View1Component },
       { path: 'view2', component: View2Component },
+      { path: '**', redirectTo: 'view1', pathMatch: 'full' }
     ]
   }
 ];
 
 @NgModule({
-  imports: [RouterModule.forRoot(routes)],
+  imports: [RouterModule.forChild(routes)],
   exports: [RouterModule]
 })
 export class AppRoutingModule { }

--- a/projects/app2/src/app/app-routing.module.ts
+++ b/projects/app2/src/app/app-routing.module.ts
@@ -2,20 +2,22 @@ import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 import { View1Component } from './pages/view1.component';
 import { View2Component } from './pages/view2.component';
-
+import { AppComponent } from './app.component';
 
 const routes: Routes = [
   {
-    path: 'app2', children: [
-      { path: '', redirectTo: 'view1', pathMatch: 'full' },
+    path: 'app2',
+    component: AppComponent,
+    children: [
       { path: 'view1', component: View1Component },
       { path: 'view2', component: View2Component },
+      { path: '**', redirectTo: 'view1', pathMatch: 'full' }
     ]
   }
 ];
 
 @NgModule({
-  imports: [RouterModule.forRoot(routes)],
+  imports: [RouterModule.forChild(routes)],
   exports: [RouterModule]
 })
 export class AppRoutingModule { }

--- a/projects/app2/src/app/app-routing.module.ts
+++ b/projects/app2/src/app/app-routing.module.ts
@@ -5,15 +5,13 @@ import { View2Component } from './pages/view2.component';
 
 
 const routes: Routes = [
-  { path: '', redirectTo: 'app2', pathMatch: 'full' },
   {
     path: 'app2', children: [
       { path: '', redirectTo: 'view1', pathMatch: 'full' },
       { path: 'view1', component: View1Component },
       { path: 'view2', component: View2Component },
     ]
-  },
-  { path: '*', redirectTo: 'app2', pathMatch: 'full' } // FIXME: Esta parte aún no funciona!
+  }
 ];
 
 @NgModule({

--- a/projects/app3/src/app/app-routing.module.ts
+++ b/projects/app3/src/app/app-routing.module.ts
@@ -5,15 +5,13 @@ import { View2Component } from './pages/view2.component';
 
 
 const routes: Routes = [
-  { path: '', redirectTo: 'app3', pathMatch: 'full' },
   {
     path: 'app3', children: [
       { path: '', redirectTo: 'view1', pathMatch: 'full' },
       { path: 'view1', component: View1Component },
       { path: 'view2', component: View2Component },
     ]
-  },
-  { path: '*', redirectTo: 'app3', pathMatch: 'full' } // FIXME: Esta parte aún no funciona!
+  }
 ];
 
 @NgModule({

--- a/projects/app3/src/app/app-routing.module.ts
+++ b/projects/app3/src/app/app-routing.module.ts
@@ -2,20 +2,21 @@ import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 import { View1Component } from './pages/view1.component';
 import { View2Component } from './pages/view2.component';
+import { AppComponent } from './app.component';
 
 
 const routes: Routes = [
   {
-    path: 'app3', children: [
-      { path: '', redirectTo: 'view1', pathMatch: 'full' },
+    path: 'app3', component: AppComponent, children: [
       { path: 'view1', component: View1Component },
       { path: 'view2', component: View2Component },
+      { path: '**', redirectTo: 'view1', pathMatch: 'full' }
     ]
   }
 ];
 
 @NgModule({
-  imports: [RouterModule.forRoot(routes)],
+  imports: [RouterModule.forChild(routes)],
   exports: [RouterModule]
 })
 export class AppRoutingModule { }

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -7,7 +7,8 @@ import { App3SharedModule } from 'projects/app3/src/app/app.module';
 
 
 const routes: Routes = [
-  { path: 'core', component: SimpleComponent }, // FIXME: Not initializing with this route, instead is going to /app1
+  { path: '', redirectTo: 'core', pathMatch: 'full' },
+  { path: 'core', component: SimpleComponent, pathMatch: 'full' }, // FIXME: Not initializing with this route, instead is going to /app1
   {
     path: 'app1',
     loadChildren: () => import('projects/app1/src/app/app.module').then(m => m.App1SharedModule),
@@ -20,12 +21,12 @@ const routes: Routes = [
     path: 'app3',
     loadChildren: () => import('projects/app3/src/app/app.module').then(m => m.App3SharedModule),
   },
-  { path: '**', pathMatch: 'full', redirectTo: 'core' }
+  { path: '**', redirectTo: 'core', pathMatch: 'full' }
 ];
 
 @NgModule({
   imports: [
-    RouterModule.forRoot(routes),
+    RouterModule.forRoot(routes, { useHash: true}),
     App1SharedModule.forRoot(),
     App2SharedModule.forRoot(),
     App3SharedModule.forRoot(),

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -7,8 +7,7 @@ import { App3SharedModule } from 'projects/app3/src/app/app.module';
 
 
 const routes: Routes = [
-  { path: '', redirectTo: 'core', pathMatch: 'full' },
-  { path: 'core', component: SimpleComponent, pathMatch: 'full' }, // FIXME: Not initializing with this route, instead is going to /app1
+  { path: 'core', component: SimpleComponent }, // FIXME: Not initializing with this route, instead is going to /app1
   {
     path: 'app1',
     loadChildren: () => import('projects/app1/src/app/app.module').then(m => m.App1SharedModule),
@@ -21,7 +20,7 @@ const routes: Routes = [
     path: 'app3',
     loadChildren: () => import('projects/app3/src/app/app.module').then(m => m.App3SharedModule),
   },
-  { path: '*', redirectTo: 'core' }
+  { path: '**', pathMatch: 'full', redirectTo: 'core' }
 ];
 
 @NgModule({

--- a/src/app/pages/simple/simple.component.ts
+++ b/src/app/pages/simple/simple.component.ts
@@ -4,7 +4,7 @@ import { Component, OnInit } from '@angular/core';
   selector: 'app-simple',
   template: `
     <p>
-      This is the local core APP without any sub-application
+      SIMPLE This is the local core APP without any sub-application
     </p>
   `,
   styles: []


### PR DESCRIPTION
Solucionado el routeo. 
Al ser sub aplicaciones, había que cargar las rutas en los módulos para sus hijos en vez de su raíz, haciendo uso de forChild (estaba forRoot)
Se han retirado algunos path que no hacían falta y dentro de los componentes de cada sub aplicación, se ha puesto la redirección al final, si no encuentra ninguna ruta de las establecidas que nos de la "view1" (o la que seleccionemos, ahora está esa)
Ejemplos de uso de variantes de ruta de redirección:
"/" ==> /core
"/app1/view5" ==> /app1/view1
"/app1/viewa" ==> /app1/view1
"/app15" ==> /core
